### PR TITLE
Fixed spammy when server doesn't respond

### DIFF
--- a/Examples/Objective-CTests/Info.plist
+++ b/Examples/Objective-CTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleVersion</key>
 	<string>34</string>
 </dict>

--- a/Examples/SwiftTests/Info.plist
+++ b/Examples/SwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleVersion</key>
 	<string>34</string>
 </dict>

--- a/MapboxCoreNavigation/Info.plist
+++ b/MapboxCoreNavigation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleVersion</key>
 	<string>34</string>
 	<key>NSPrincipalClass</key>

--- a/MapboxCoreNavigationTests/Info.plist
+++ b/MapboxCoreNavigationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Location Usage Description</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>

--- a/MapboxNavigation/Info.plist
+++ b/MapboxNavigation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleVersion</key>
 	<string>34</string>
 	<key>NSPrincipalClass</key>

--- a/MapboxNavigationTests/Info.plist
+++ b/MapboxNavigationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Location Usage Description</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Alternatively, to install Mapbox Navigation using [Carthage](https://github.com/
 
 1. Create a [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#github-repositories) with the following dependency:
    ```cartfile
-   github "flitsmeister/flitsmeister-navigation-ios" ~> 1.0.2
+   github "flitsmeister/flitsmeister-navigation-ios" ~> 1.0.3
    ```
 
 1. Run `carthage update --platform iOS` to build just the iOS dependencies.

--- a/RouteTest/Info.plist
+++ b/RouteTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.2</string>
+	<string>1.0.3</string>
 	<key>CFBundleVersion</key>
 	<string>34</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/custom-navigation.md
+++ b/custom-navigation.md
@@ -20,7 +20,7 @@ To install Mapbox Core Navigation using [CocoaPods](https://cocoapods.org/):
 
 1. Specify the following dependency in your Podfile:
    ```ruby
-   pod 'MapboxCoreNavigation', '~> 1.0.2'
+   pod 'MapboxCoreNavigation', '~> 1.0.3'
    ```
 
 1. Run `pod install` and open the resulting Xcode workspace.
@@ -31,7 +31,7 @@ Alternatively, to install Mapbox Core Navigation using [Carthage](https://github
 
 1. Specify the following dependency in your Cartfile:
    ```cartfile
-   github "mapbox/mapbox-navigation-ios" ~> 1.0.2
+   github "mapbox/mapbox-navigation-ios" ~> 1.0.3
    ```
 
 1. Run `carthage update --platform iOS` to build just the iOS dependencies.


### PR DESCRIPTION
# Description

Last week, we encountered downtime on our navigation servers. It seemed that because of the downtime, a huge spike in iOS navigation requests occurred. We saw 3000% increase of requests for example, where we expect 20k requests we got 500k. We were puzzled why that would be. 

Found out that the navigation SDK is the culprit. 

**How it works:**
1. The user drives on their route that was successfully calculated
2. The SDK tries to find a faster route by doing a routing call to our servers every 2 mins (and some other requirements)
3. After a while, the servers get downtime
4. The SDK tries to search for a faster route again, but that call fails
5. Because the call fails, the guard `guard let route = route` fails, and the `lastLocationDate` isn't set to nil
6. That means that every location update thereafter will try to search for a faster route by doing a routing call
7. ???
8. Server-hosting: PROFIT! 💰

| Spam |
:---:
![image](https://user-images.githubusercontent.com/7554912/86606699-a6149880-bfa8-11ea-9eda-4d0e75de4fce.png)

# The fix

The fix is two-fold:
1. Always setting the `lastLocationDate` to `nil` when the call is done, even if it fails. This means that the user has to wait 2mins (and other requirements) before it tries again in case of failure. That is fine in my opinion
2. Only do one call at a time. When the server times out, it should wait for that before it retries. 

This will reduce the spammy calls to our servers